### PR TITLE
changes to Docker file to accomodate oc client copy in ocp-ci

### DIFF
--- a/docker-container-executor/Dockerfile
+++ b/docker-container-executor/Dockerfile
@@ -1,11 +1,7 @@
 FROM fedora:latest
 MAINTAINER Keycloak QE <keycloak-qe@redhat.com>
-ENV OC_VERSION=stable
-ARG ARCH
-ARG VERSION
 ENV KUBECONFIG=/tmp/tests/ansible-tests/kubeconfig
 ENV JUNIT_OUTPUT_DIR=/tmp/tests/ansible-tests/junit-results
-
 # Labels consumed by Red Hat build service
 LABEL com.redhat.component="interop-ocp-ci" \
       name="keycloakqe/interop-ocp-ci" \
@@ -15,19 +11,12 @@ LABEL com.redhat.component="interop-ocp-ci" \
       io.openshift.tags="rhbk,integration,interop" \
       maintainer="keycloak-qe@redhat.com" \
       vendor="Red Hat Single Sign-On product" \
-      version=$VERSION
+      version="latest"
 
 RUN dnf update -y && dnf install -y which python3 python3-pip rust cargo openssl-devel libffi-devel \
         sudo openssl ansible python-yaml
 
 RUN pip install kubernetes
-
-# Install OpenShift & Kubernetes CLI
-RUN curl https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/${OC_VERSION}/openshift-client-linux.tar.gz -o openshift-client-linux.tar.gz && \
-    tar xzvf openshift-client-linux.tar.gz && \
-    install -o root -g root -m 0755 oc /usr/local/bin/oc && \
-    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
-    rm -f openshift-client-linux.tar.gz oc kubectl README.md
 
 RUN mkdir -p /tmp/tests/ansible-tests
 WORKDIR /tmp/tests/ansible-tests
@@ -37,11 +26,6 @@ RUN chmod g=u /etc/passwd /etc/group \
   && chgrp -R 0 /tmp \
   && chmod -R g=u /tmp
 
-COPY configs/keycloak-resource.yaml /tmp/tests/ansible-tests/configs/keycloak-resource.yaml
-COPY roles/deploy_image/tasks/deploy_image.yml /tmp/tests/ansible-tests/roles/deploy_image/tasks/deploy_image.yml
-COPY roles/deploy_image/tasks/deploy_image.yml /tmp/tests/ansible-tests/roles/deploy_image/tasks/main.yml
-COPY vars/global.yml /tmp/tests/ansible-tests/vars/global.yml
-COPY ansible.cfg /tmp/tests/ansible-tests/ansible.cfg
-COPY test-ocp-ci-rhbk.yml /tmp/tests/ansible-tests/test-ocp-ci-rhbk.yml
+COPY . /tmp/tests/ansible-tests/
 
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
We are building image from this Dockerfile on OCP-CI, made some changes to accommodate OC client copy from another image on OCP-CI

cc : @ikhomyn 