### PR TITLE
disable prometheusrule-validation

### DIFF
--- a/configs/keycloak-resource.yaml
+++ b/configs/keycloak-resource.yaml
@@ -8,3 +8,4 @@ spec:
   externalAccess:
     enabled: true
   instances: 1
+  DisableDefaultServiceMonitor: true


### PR DESCRIPTION
Fixes issue rhsso operator fails to create a new instance of rhsso container getting into failing phase because of this event:
`admission webhook "prometheusrule-validation.managed.openshift.io" denied the request: Prevented from accessing Red Hat managed resources. This is in an effort to prevent harmful actions that may cause unintended consequences or affect the stability of the cluster. If you have any questions about this, please reach out to Red Hat support at https://access.redhat.com/support`